### PR TITLE
Build Error in angular files after prod build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,9 +30,15 @@ module.exports = async (env, options) => {
           use: "ts-loader"
         },
         {
-          test: /\.html$/,
-          exclude: /node_modules/,
-          use: "html-loader"
+          test: /\.(html)$/,
+          exclude: "/node_modules/",
+          use: [{
+            loader: 'html-loader',
+            options: {
+              minimize: true,
+              caseSensitive: true
+            }
+          }]
         },
         {
           test: /\.(png|jpg|jpeg|gif)$/,


### PR DESCRIPTION
Running npm run build causes webpack to minimize the angular files by performing compression.
But this also causes it to modify all angular directives to lower case i.e. (*ngIf becomes *ngif),
Which caused error when runs on browser.

This patch will fix above mentioned error.