### PR TITLE
Move manifest image prep from code to webpack

### DIFF
--- a/src/taskpane/app/excel.app.component.ts
+++ b/src/taskpane/app/excel.app.component.ts
@@ -1,14 +1,5 @@
 import { Component } from "@angular/core";
 
-// images references in the manifest
-/* eslint-disable no-unused-vars */
-import icon16 from "../../../assets/icon-16.png";
-import icon32 from "../../../assets/icon-32.png";
-import icon64 from "../../../assets/icon-64.png";
-import icon80 from "../../../assets/icon-80.png";
-import icon128 from "../../../assets/icon-128.png";
-/* eslint-enable no-unused-vars */
-
 /* global console, Excel */
 
 @Component({

--- a/src/taskpane/app/onenote.app.component.ts
+++ b/src/taskpane/app/onenote.app.component.ts
@@ -1,14 +1,5 @@
 import { Component } from "@angular/core";
 
-// images references in the manifest
-/* eslint-disable no-unused-vars */
-import icon16 from "../../../assets/icon-16.png";
-import icon32 from "../../../assets/icon-32.png";
-import icon64 from "../../../assets/icon-64.png";
-import icon80 from "../../../assets/icon-80.png";
-import icon128 from "../../../assets/icon-128.png";
-/* eslint-enable no-unused-vars */
-
 @Component({
   selector: "app-home",
   templateUrl: "./app.component.html",

--- a/src/taskpane/app/outlook.app.component.ts
+++ b/src/taskpane/app/outlook.app.component.ts
@@ -1,14 +1,5 @@
 import { Component } from "@angular/core";
 
-// images references in the manifest
-/* eslint-disable no-unused-vars */
-import icon16 from "../../../assets/icon-16.png";
-import icon32 from "../../../assets/icon-32.png";
-import icon64 from "../../../assets/icon-64.png";
-import icon80 from "../../../assets/icon-80.png";
-import icon128 from "../../../assets/icon-128.png";
-/* eslint-enable no-unused-vars */
-
 @Component({
   selector: "app-home",
   templateUrl: "./app.component.html",

--- a/src/taskpane/app/powerpoint.app.component.ts
+++ b/src/taskpane/app/powerpoint.app.component.ts
@@ -1,14 +1,5 @@
 import { Component } from "@angular/core";
 
-// images references in the manifest
-/* eslint-disable no-unused-vars */
-import icon16 from "../../../assets/icon-16.png";
-import icon32 from "../../../assets/icon-32.png";
-import icon64 from "../../../assets/icon-64.png";
-import icon80 from "../../../assets/icon-80.png";
-import icon128 from "../../../assets/icon-128.png";
-/* eslint-enable no-unused-vars */
-
 /* global Office, console */
 
 @Component({

--- a/src/taskpane/app/project.app.component.ts
+++ b/src/taskpane/app/project.app.component.ts
@@ -1,14 +1,5 @@
 import { Component } from "@angular/core";
 
-// images references in the manifest
-/* eslint-disable no-unused-vars */
-import icon16 from "../../../assets/icon-16.png";
-import icon32 from "../../../assets/icon-32.png";
-import icon64 from "../../../assets/icon-64.png";
-import icon80 from "../../../assets/icon-80.png";
-import icon128 from "../../../assets/icon-128.png";
-/* eslint-enable no-unused-vars */
-
 /* global Office, console*/
 
 @Component({

--- a/src/taskpane/app/word.app.component.ts
+++ b/src/taskpane/app/word.app.component.ts
@@ -1,14 +1,5 @@
 import { Component } from "@angular/core";
 
-// images references in the manifest
-/* eslint-disable no-unused-vars */
-import icon16 from "../../../assets/icon-16.png";
-import icon32 from "../../../assets/icon-32.png";
-import icon64 from "../../../assets/icon-64.png";
-import icon80 from "../../../assets/icon-80.png";
-import icon128 from "../../../assets/icon-128.png";
-/* eslint-enable no-unused-vars */
-
 /* global Word */
 
 @Component({

--- a/test/end-to-end/webpack.config.js
+++ b/test/end-to-end/webpack.config.js
@@ -2,6 +2,7 @@
 
 const devCerts = require("office-addin-dev-certs");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const CopyWebpackPlugin = require("copy-webpack-plugin");
 const path = require("path");
 const webpack = require("webpack");
 
@@ -75,6 +76,14 @@ module.exports = async (env, options) => {
         filename: "app.component.html",
         template: "./src/taskpane/app/app.component.html",
         chunks: ["polyfill", "app.component"],
+      }),
+      new CopyWebpackPlugin({
+        patterns: [
+          {
+            from: "assets/icon-*",
+            to: "assets/[name][ext][query]",
+          },
+        ],
       }),
     ],
     devServer: {

--- a/test/unit/images.d.ts
+++ b/test/unit/images.d.ts
@@ -1,1 +1,0 @@
-declare module "*.png";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,6 +74,10 @@ module.exports = async (env, options) => {
       new CopyWebpackPlugin({
         patterns: [
           {
+            from: "assets/icon-*",
+            to: "assets/[name][ext][query]",
+          },
+          {
             from: "manifest*.xml",
             to: "[name]." + buildType + "[ext]",
             transform(content) {


### PR DESCRIPTION
Currently there are a bunch of import statements for the icon.png images in the .ts files, but the files and the html don't reference those images at all. The references to them are in the manifest.xml files. Webpack doesn't get the resources referenced in the XML like it does in the typescript, javascript, and html and so those were added so that webpack would have those images in the deployment location.

At first glance it's not clear why the import statements were needed and it caused some challenges when making unit tests. The import statements were modified to allow for the unit tests, but this ended up breaking the manifest references (hidden by cache hits). In order to accommodate the unit tests, make sure the images are there for the manifest, and remove potential code confusion this change moves the responsibility of copying the image files to the webpack config file instead of the code files.